### PR TITLE
Change from publicbits.org -> datprotocol.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ var extend = require('xtend')
 
 var DAT_DOMAIN = 'dat.local'
 var DEFAULT_DISCOVERY = [
-  'discovery1.publicbits.org',
-  'discovery2.publicbits.org'
+  'discovery1.datprotocol.com',
+  'discovery2.datprotocol.com'
 ]
 var DEFAULT_BOOTSTRAP = [
-  'bootstrap1.publicbits.org:6881',
-  'bootstrap2.publicbits.org:6881',
-  'bootstrap3.publicbits.org:6881',
-  'bootstrap4.publicbits.org:6881'
+  'bootstrap1.datprotocol.com:6881',
+  'bootstrap2.datprotocol.com:6881',
+  'bootstrap3.datprotocol.com:6881',
+  'bootstrap4.datprotocol.com:6881'
 ]
 
 var DEFAULT_OPTS = {


### PR DESCRIPTION
As discussed in Dat Protocol WG (https://github.com/datprotocol/working-group/issues/17), moving discovery services to datprotocol.com so folks know what the network activity is for.